### PR TITLE
using viewmodel->terminate() to check whenever view has layout

### DIFF
--- a/module/Application/Module.php
+++ b/module/Application/Module.php
@@ -9,7 +9,6 @@ use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
 use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\MvcEvent;
-use Zend\View\Model\JsonModel;
 
 class Module  implements
     AutoloaderProviderInterface,
@@ -77,7 +76,7 @@ class Module  implements
      */
     public function onRender(MvcEvent $e)
     {
-        if (!$e->getViewModel() instanceof JsonModel) {
+        if (!$e->getViewModel()->terminate()) {
             $entityManager = $this->services->get('Doctrine\ORM\EntityManager');
             $e->getViewModel()
               ->setVariable('modules_list', $entityManager->getRepository('Application\Entity\ModuleList')->findAll());


### PR DESCRIPTION
in favor of usage of #88 that need to set sitemap xml that not using layout. Changed : 

``` php
!$e->getViewModel() instanceof JsonModel
```

to 

``` php
!$e->getViewModel()->terminate()
```

so it has general condition ( for example : FeedModel or others ).
