### PR TITLE
hotfix : restrict other "in db" modules to be download-able

### DIFF
--- a/module/Application/src/Application/Controller/DownloadController.php
+++ b/module/Application/src/Application/Controller/DownloadController.php
@@ -11,16 +11,16 @@ class DownloadController extends AbstractActionController
     /**
      * @var array
      */
-    private $applicationConfig;
+    private $modulesList;
 
     /**
-     * Construct applicationConfig
+     * Construct $modulesList
      *
-     * @param array $applicationConfig
+     * @param array $modulesList
      */
-    public function __construct(array $applicationConfig)
+    public function __construct(array $modulesList)
     {
-        $this->applicationConfig = $applicationConfig;
+        $this->modulesList = $modulesList;
     }
 
     /**
@@ -32,10 +32,9 @@ class DownloadController extends AbstractActionController
     {
         $module = $this->params()->fromRoute('module', '');
         $compress = $this->params()->fromRoute('compress', 'zip');
-        $modules           = $this->applicationConfig['modules'];
 
         $response = $this->getResponse();
-        if (in_array($module, $modules)) {
+        if (in_array($module, $this->modulesList)) {
             $currDateTime = date('Y-m-dHis');
 
             $fileToArchive  = $module.'.'.(($compress == 'zip') ? 'zip' : 'bz2');

--- a/module/Application/src/Application/Factory/Controller/DownloadControllerFactory.php
+++ b/module/Application/src/Application/Factory/Controller/DownloadControllerFactory.php
@@ -2,9 +2,9 @@
 
 namespace Application\Factory\Controller;
 
+use Application\Controller\DownloadController;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
-use Application\Controller\DownloadController;
 
 class DownloadControllerFactory implements FactoryInterface
 {
@@ -14,7 +14,13 @@ class DownloadControllerFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $services = $serviceLocator->getServiceLocator();
+        $moduleList = [];
+        foreach ($services->get('Doctrine\ORM\EntityManager')
+                               ->getRepository('Application\Entity\ModuleList')
+                               ->findAll() as $module) {
+            $moduleList[] = $module->getModuleName();
+        }
 
-        return new DownloadController($services->get('ApplicationConfig'));
+        return new DownloadController($moduleList);
     }
 }


### PR DESCRIPTION
currently, list module that can be downloaded comes from ApplicationConfig which should be avoided and should use in db modules instead.
